### PR TITLE
Fix nav to expenditure

### DIFF
--- a/app/controllers/expenditures_controller.rb
+++ b/app/controllers/expenditures_controller.rb
@@ -78,6 +78,8 @@ class ExpendituresController < OrganizationAwareController
 
   # GET /expenditures/1
   def show
+    asset = Asset.find_by(object_key: params[:id])
+    @expenditure = Expenditure.find_by(grant_id: asset.grants.first.id)
 
     add_breadcrumb @expenditure.expense_type, expenditures_path(:type => @expenditure.expense_type)
     add_breadcrumb @expenditure

--- a/app/controllers/expenditures_controller.rb
+++ b/app/controllers/expenditures_controller.rb
@@ -78,8 +78,12 @@ class ExpendituresController < OrganizationAwareController
 
   # GET /expenditures/1
   def show
-    asset = Asset.find_by(object_key: params[:id])
-    @expenditure = Expenditure.find_by(grant_id: asset.grants.first.id)
+    if Asset.exists?(object_key: params[:id])
+      asset = Asset.find_by(object_key: params[:id])
+      @expenditure = Expenditure.find_by(grant_id: asset.grants.first.id)
+    else
+      @expenditure = Expenditure.find_by_object_key(params[:id])
+    end
 
     add_breadcrumb @expenditure.expense_type, expenditures_path(:type => @expenditure.expense_type)
     add_breadcrumb @expenditure


### PR DESCRIPTION
1.  This pull request fixes a bug where users would click on an asset listed on a grant's show page, which had caused an error.  The error occurred because clicking on the asset called upon the expenditure's show action, but the expenditure's controller did not have any code to identify which expenditure to show.

2.  This pull request identifies an expenditure that matches the asset that the user clicked on, but this might not be the desired behavior because a single asset might have many expenditures.