### PR TITLE
Created new views for the grants index page and the grant show page t…

### DIFF
--- a/app/views/grants/_index_table.html.haml
+++ b/app/views/grants/_index_table.html.haml
@@ -1,0 +1,70 @@
+:ruby
+  table_dom_id = SecureRandom.hex
+  show_actions ||= 0
+
+- if show_actions == 1
+  #table_actions.btn-group
+    = render :partial => "grants/index_actions"
+
+%table.table.table-hover{:id => table_dom_id, :data => {:toggle => 'table',
+  :pagination => 'true',
+  :show_pagination_switch => 'true',
+  :page_list => "[5, 10, 20, 50, 100, 200]",
+  :page_size => current_user.num_table_rows,
+  :search => 'false',
+  :toolbar => "#table_actions",
+  :export_types => "['csv', 'txt', 'excel']",
+  :show_export => 'true',
+  :show_columns => 'true',
+  :show_footer => "#{grants.count > 0}",
+  :show_toggle => 'true'}}
+  %thead
+    %tr
+      %th.left{:data => {:visible => 'false'}} Object Key
+      %th.left{:data => {:visible => 'false', :sortable => 'true'}} Recepient
+      %th.left{:data => {:sortable => 'true'}} Grant
+      %th.left{:data => {:sortable => 'true'}} Fiscal Year
+      %th.left{:data => {:sortable => 'true'}} Source
+      %th.right{:data => {:sortable => 'true', :formatter => 'currency_formatter', :footer_formatter => 'sum_amount'}} Amount
+      %th.right{:data => {:sortable => 'true', :formatter => 'integer_formatter', :footer_formatter => 'sum_expenditures'}} Expenditures
+      %th.right{:data => {:sortable => 'true', :formatter => 'currency_formatter', :footer_formatter => 'sum_total_spent'}} Total Expended
+
+  %tbody
+    - grants.each do |grant|
+      %tr{:id => grant.object_key, :class => 'action-path'}
+        %td.left= grant.object_key
+        %td.left= grant.organization.short_name
+        %td.left= grant.grant_number
+        %td.center= format_as_fiscal_year(grant.fy_year)
+        %td.left= grant.funding_source
+        %td.right= grant.amount.to_i
+        %td.right= grant.expenditures.count
+        %td.right= grant.spent.to_i
+
+= render :partial => 'shared/table_scripts', :locals => {:table_id => table_dom_id, :path_pattern => grant_path("xxx")}
+
+:javascript
+
+  function sum_expenditures(col_data) {
+    var sum = 0;
+    for (i = 0; i < col_data.length; i++) {
+      sum += parseInt(col_data[i][6]);
+    }
+    return "<strong>" + integer_formatter(sum) + "</strong>";
+  };
+
+  function sum_amount(col_data) {
+    var sum = 0;
+    for (i = 0; i < col_data.length; i++) {
+      sum += parseInt(col_data[i][5]);
+    }
+    return "<strong>" + currency_formatter(sum) + "</strong>";
+  };
+
+  function sum_total_spent(col_data) {
+    var sum = 0;
+    for (i = 0; i < col_data.length; i++) {
+      sum += parseInt(col_data[i][7]);
+    }
+    return "<strong>" + currency_formatter(sum) + "</strong>";
+  };

--- a/app/views/grants/_summary.html.haml
+++ b/app/views/grants/_summary.html.haml
@@ -1,0 +1,5 @@
+= format_field("Fund", @grant.funding_source)
+= format_field("Fiscal Year", @grant.fiscal_year)
+= format_field("Budget", format_as_currency(@grant.amount))
+= format_field("Expenditures", format_as_currency(@grant.expenditures.sum(:amount)))
+


### PR DESCRIPTION
…hat refer to the expenditures model so that it displays the correct number of expenditures and the amount total spent on expenditures. [#99616226]

1.  This pull request updates the grants views so that they work with the expenditures model.  Previously, only Transam Transit had views for grants.  Although Transit did have fields in the views for expenditures, these views acted as though the only expenditures were asset purchases.