### PR TITLE
Add validate_engine_seeds rake task

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,7 @@ general_ledger_account_types = [
   {:active => 1, :name => 'Equity Account',     :description => 'Accounts representing the residual equity the business.'},
   {:active => 1, :name => 'Revenue Account',    :description => 'Accounts representing the businesses gross earnings.'},
   {:active => 1, :name => 'Expense Account',    :description => 'Accounts representing the expenditures for the business.'},
-  {:active => 1, :name => 'Contra Account',     :description => 'Accounts representing negative balances due to accu,ulated depreciation etc.'}
+  {:active => 1, :name => 'Contra Account',     :description => 'Accounts representing negative balances due to accumulated depreciation etc.'}
 ]
 
 depreciation_calculation_types = [

--- a/db/validate_seeds_script.rb
+++ b/db/validate_seeds_script.rb
@@ -1,0 +1,44 @@
+# Validates that engine seed data has loaded as expected
+# Added to the dynamically generated tmp/validate_seeds_data.rb file
+# Via the transam_{engine_name}:validate_engine_seeds rake task
+# Which should only be called from an app-level validate_engine_seeds rake task
+
+# Initialize the standard table name arrays in case they were never created
+lookup_tables ||= []
+replace_tables ||= []
+merge_tables ||= []
+
+# Validate rows from tables mentioned in the standard table name arrays
+%w{lookup_tables replace_tables merge_tables}.each do |table_name_array_name|
+
+  puts "    Validating #{table_name_array_name}"
+  table_name_array = eval(table_name_array_name)
+  table_name_array.each do |table_name|
+    puts "      #{table_name}"
+    data = eval(table_name)
+    klass = table_name.classify.constantize
+    data.each.with_index do |row, i|
+      row_does_not_exist = klass.find_by(row).nil?
+      row_is_not_unique = klass.where(row).count > 1
+
+      puts "        #{row.inspect} does not exist in this environment." if row_does_not_exist
+      puts "        #{row.inspect} is not unique in this environment." if row_is_not_unique
+
+      # Skip this check with merge_tables, where id will vary
+      unless table_name_array_name == "merge_tables"
+        row_has_an_unexpected_id = false
+        unless row_does_not_exist || row_is_not_unique
+          row_has_an_unexpected_id = klass.find_by(row).id != i + 1
+        end
+
+        puts "        #{row.inspect} has an unexpected id in this environment. Got #{klass.find_by(row).id}. Expected #{i + 1}." if row_has_an_unexpected_id
+      end
+    end
+  end
+
+end
+
+# Validate specially handled tables (like reports)
+# NOTE: this will need to be updated by hand if we add tables or change logic
+
+puts "    Validating specially handled tables"

--- a/db/validate_seeds_script.rb
+++ b/db/validate_seeds_script.rb
@@ -1,5 +1,5 @@
 # Validates that engine seed data has loaded as expected
-# Added to the dynamically generated tmp/validate_seeds_data.rb file
+# Added to a dynamically generated validate_seeds_data.rb file
 # Via the transam_{engine_name}:validate_engine_seeds rake task
 # Which should only be called from an app-level validate_engine_seeds rake task
 

--- a/lib/tasks/validate_engine_seeds.rake
+++ b/lib/tasks/validate_engine_seeds.rake
@@ -1,0 +1,91 @@
+# Validates that engine seed data has loaded as expected
+# Should only be called from an app-level validate_engine_seeds rake task
+
+# Copies engine seed data into a temp file
+# Adds the contents of a validation script to the file
+# Runs the complete file to print validation results
+# Then deletes the file
+
+namespace :transam_accounting do
+  desc "validate engine seeds"
+  task :validate_engine_seeds, [:app_root] => [:environment] do |t, args|
+
+    # Skip the task unless certain conditions are met
+    puts("  Rake task missing the app_root argument (an absolute path string to the app-level root).") || next unless args[:app_root]
+    puts("  No db/seeds.rb file found for this engine.") || next unless File.exist?(File.join(TransamAccounting::Engine.root, "db", "seeds.rb"))
+    puts("  No db/validate_seeds_script.rb file found for this engine.") || next unless File.exist?(File.join(TransamAccounting::Engine.root, "db", "validate_seeds_script.rb"))
+
+    # Read the full db/seeds.rb file
+    seeds_file = File.readlines(File.join(TransamAccounting::Engine.root, "db", "seeds.rb"))
+
+    # Isolate the data from the creation logic
+
+    # Get table rows
+    data_start_line_nums = []
+    data_end_line_nums = []
+    seeds_file.each.with_index do |line, i|
+      data_start_line_nums << i if line =~ /\w+ += +\[/
+      data_end_line_nums << i if line =~ / *\] *\n/
+    end
+
+    data_line_ranges = []
+    data_start_line_nums.each.with_index do |num, i|
+      data_line_ranges << (num..data_end_line_nums[i])
+    end
+
+    seeds_data = seeds_file.select.with_index do |_line, i|
+      data_line_ranges.any? do |range|
+        range.include?(i)
+      end
+    end
+
+    # Replace 1/0 with true/false for boolean fields
+    # Needed for apps that use postgresql, which won't convert 1/0 implicitly
+    # Will have to be updated by hand
+    seeds_data.each do |line|
+      line.gsub!(/:?active *(=>|:) *1/, ":active => true")
+      line.gsub!(/:?active *(=>|:) *0/, ":active => false")
+      line.gsub!(/:?show_in_nav *(=>|:) *1/, ":show_in_nav => true")
+      line.gsub!(/:?show_in_nav *(=>|:) *0/, ":show_in_nav => false")
+      line.gsub!(/:?show_in_dashboard *(=>|:) *1/, ":show_in_dashboard => true")
+      line.gsub!(/:?show_in_dashboard *(=>|:) *0/, ":show_in_dashboard => false")
+    end
+
+    # Get table names (listed in lookup_tables, replace_tables, merge_tables)
+    add_line = false
+    seeds_file.each do |line|
+      add_line = true if line =~ /\w+_tables += +%w\{/
+      seeds_data << line if add_line == true
+      add_line = false if line =~ /.*\} *\n/
+    end
+
+    # NOTE: this leaves out specially handled tables (like reports)
+    # The validate seeds script should deal with these individually
+
+    # Read the full db/validate_seeds_script.rb file
+    seeds_script = File.readlines(File.join(TransamAccounting::Engine.root, "db", "validate_seeds_script.rb"))
+
+    # Create the temp file validate_seeds_data.rb
+    File.open("validate_seeds_data.rb", "wb") do |f|
+
+      # Add a line to require the app-level rails environment
+      f.write("require \"#{File.join(args[:app_root], "config", "environment.rb")}\"\n")
+
+      # Add the seed data
+      seeds_data.each do |line|
+        f.write(line)
+      end
+
+      # Add the validate seeds script
+      seeds_script.each do |line|
+        f.write(line)
+      end
+    end
+
+    # Run the completed validate_seeds_data.rb file, then delete it
+    if File.exist?("validate_seeds_data.rb")
+      ruby "validate_seeds_data.rb"
+      File.delete("validate_seeds_data.rb")
+    end
+  end
+end


### PR DESCRIPTION
Adds a task to validate that engine seed data has loaded as expected. Should be called from the app level, via `bundle exec rake validate_engine_seeds ENV=env_to_validate`.